### PR TITLE
Re-added the requirements.txt to the correct root location

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langextract
+pyobjc
+utitools


### PR DESCRIPTION
Added the requirements.txt to the root location as it must be there for the user to run installation steps without any issues. Previously the file was under the app directory which would cause an error while executing the dependency installation step. 