### PR TITLE
Added pydantic to requirements.txt as it's needed in query_gen.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 llama-cpp-python
 pyobjc
 utitools
+pydantic


### PR DESCRIPTION
Must've been missed in requirements.txt

Fixes following error:
`ModuleNotFoundError: No module named 'pydantic'`